### PR TITLE
feat: add LAN mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ in your nixos configuration:
 }
 ```
 
+### LAN mode (Bonjour/mDNS)
+
+Enable LAN auto-discovery and default to the machine hostname with TLS disabled. In LAN mode, the default hostname becomes `hostname.local` for mDNS:
+
+```nix
+{
+  services.nixos-passthru-cache.enable = true;
+  services.nixos-passthru-cache.lanMode = true;
+  # hostName will default to networking.hostName + ".local"; TLS (forceSSL) defaults to false
+}
+```
+This publishes an `_http._tcp` Bonjour service on port 80 via Avahi and opens mDNS in the firewall.
+
 ## Demo instances
 
 - We have deployed a binary cache at [https://hetzner-cache.numtide.com](https://hetzner-cache.numtide.com) for testing local caching in hetzner networks.


### PR DESCRIPTION
Useful when deploying the cache on a LAN network (eg: at NixCon 2025)
