### PR TITLE
fix: dhparams infinite recursion on nixos-unstable

### DIFF
--- a/modules/nixos/nixos-passthru-cache/default.nix
+++ b/modules/nixos/nixos-passthru-cache/default.nix
@@ -132,7 +132,11 @@ in
         in
         map escapeIPv6 resolvers;
 
-      sslDhparam = config.security.dhparams.params.nginx.path;
+      sslDhparam =
+        if (lib.versionOlder (lib.versions.majorMinor lib.version) "26.05") then
+          config.security.dhparams.params.nginx.path
+        else
+          true;
     };
 
     services.nginx.virtualHosts."nixos-passthru-cache" = {
@@ -209,6 +213,8 @@ in
     };
     security.dhparams = {
       enable = true;
+    }
+    // lib.optionalAttrs (lib.versionOlder (lib.versions.majorMinor lib.version) "26.05") {
       params.nginx = { };
     };
 


### PR DESCRIPTION
Caused by https://www.github.com/NixOS/nixpkgs/pull/452972

https://www.github.com/NixOS/nixpkgs/pull/452972#issuecomment-4070408583

Fix found at https://www.github.com/nix-community/srvos/commit/f3f0277b1dee1bfd058c5b8b98cb25558d95f03f

Credit to Bart Oostveen <bart@bartoostveen.nl> and zowoq <59103226+zowoq@users.noreply.github.com>